### PR TITLE
getoptions: empty OPTARG after the parsing is over.

### DIFF
--- a/getoptions.sh
+++ b/getoptions.sh
@@ -170,6 +170,7 @@ getoptions() {
   _2 'esac'
   _2 'shift'
   _1 'done'
+  _1 'unset OPTARG'
   _1 '[ $# -eq 0 ] && return 0'
   [ "$_error" ] && _1 "$_error" '"$@" >&2 && exit 1'
   _1 'case $2 in'

--- a/getoptions.sh
+++ b/getoptions.sh
@@ -170,8 +170,7 @@ getoptions() {
   _2 'esac'
   _2 'shift'
   _1 'done'
-  _1 'unset OPTARG'
-  _1 '[ $# -eq 0 ] && return 0'
+  _1 '[ $# -eq 0 ] && { unset OPTARG; return 0 ;}'
   [ "$_error" ] && _1 "$_error" '"$@" >&2 && exit 1'
   _1 'case $2 in'
   _2 "unknown) echo \"unrecognized option '\$1'\" ;;"


### PR DESCRIPTION
After the option parsing, unset the OPTARG variable. This way some functions can make use of the existence of it, which eventually makes calling `:function` from `param` more meaningful.