### PR TITLE
Add support for `--with` and `--without` flags

### DIFF
--- a/lib/getoptions.sh
+++ b/lib/getoptions.sh
@@ -74,6 +74,7 @@ getoptions() {
 		while loop "$@" && shift; do
 			case $1 in
 				--\{no-\}*) i=${1#--?no-?}; sw="$sw${sw:+|}'--$i'|'--no-$i'" ;;
+				--with\{out\}-*) i=${1#--with?out?-}; sw="$sw${sw:+|}'--with-$i'|'--without-$i'" ;;
 				[-+]? | --*) sw="$sw${sw:+|}'$1'" ;;
 				*) kv "$1"
 			esac
@@ -104,7 +105,7 @@ getoptions() {
 		_3 "$sw)"
 		_4 'set -- "$1" "$@"'
 		_4 '[ ${OPTARG+x} ] && {'
-		_5 'case $1 in --no-*) set "noarg" "${1%%\=*}"; break; esac'
+		_5 'case $1 in --no-*|--without-*) set "noarg" "${1%%\=*}"; break; esac'
 		_5 '[ "${OPTARG:-}" ] && { shift; OPTARG=$2; } ||' "OPTARG=$on"
 		_4 "} || OPTARG=$off"
 		valid "$1" '$OPTARG'
@@ -139,7 +140,7 @@ getoptions() {
 	_3 '--?*=*) OPTARG=$1; shift'
 	_wa '"${OPTARG%%\=*}" "${OPTARG#*\=}"'
 	_4 ';;'
-	_3 '--no-*) unset OPTARG ;;'
+	_3 '--no-*|--without-*) unset OPTARG ;;'
 	[ "$_alt" ] || {
 		[ "$_opts" ] && _op "-[$_opts]?*" '' ';;'
 		[ ! "$_flags" ] || _op "-[$_flags]?*" - 'OPTARG= ;;'

--- a/spec/getoptions_help_spec.sh
+++ b/spec/getoptions_help_spec.sh
@@ -26,6 +26,7 @@ Describe "getoptions_help()"
 			flag FLAG_A -a +a --{no-}flag-a -- "flag a"
 			setup - width:25 hidden
 			param PARAM_P -p -- "param p"
+			option OPTION_W --with{out}-flag-w -- "option w"
 			option OPTION_O -o -- "option o"
 			msg -- "footer"
 		}
@@ -36,7 +37,9 @@ Describe "getoptions_help()"
 		The line 4 should eq "  -a, +a, --{no-}flag-a "
 		The line 5 should eq "                    flag a"
 		The line 6 should eq "  -p PARAM_P             param p"
-		The line 7 should eq "  -o[=OPTION_O]          option o"
-		The line 8 should eq "footer"
+		The line 7 should eq "          --with{out}-flag-w[=OPTION_W] "
+		The line 8 should eq "                         option w"
+		The line 9 should eq "  -o[=OPTION_O]          option o"
+		The line 10 should eq "footer"
 	End
 End

--- a/spec/getoptions_spec.sh
+++ b/spec/getoptions_spec.sh
@@ -328,14 +328,20 @@ Describe "getoptions()"
 				flag FLAG_D --{no-}flag-d
 				flag FLAG_E --no-flag-e
 				flag FLAG_F --{no-}flag-f
+				flag FLAG_G --with{out}-flag-g
+				flag FLAG_H --without-flag-h
+				flag FLAG_I --with{out}-flag-i
 			}
-			When call parse -a +b --flag-c --flag-d --no-flag-e --no-flag-f
+			When call parse -a +b --flag-c --flag-d --no-flag-e --no-flag-f --with-flag-g --without-flag-h --without-flag-i
 			The variable FLAG_A should eq 1
 			The variable FLAG_B should eq ""
 			The variable FLAG_C should eq 1
 			The variable FLAG_D should eq 1
 			The variable FLAG_E should eq ""
 			The variable FLAG_F should eq ""
+			The variable FLAG_G should eq 1
+			The variable FLAG_H should eq ""
+			The variable FLAG_I should eq ""
 		End
 
 		It "can change the set value"
@@ -525,6 +531,18 @@ Describe "getoptions()"
 			It "displays error"
 				When run parse --no-option=value
 				The stderr should eq "Does not allow an argument: --no-option"
+				The status should be failure
+			End
+		End
+
+		Context "when specified an argument to --without-option"
+		    parser_definition() {
+				setup ARGS
+				option OPTION --without-option
+		    }
+			It "displays error"
+			    When run parse --without-option=value
+				The stderr should eq "Does not allow an argument: --without-option"
 				The status should be failure
 			End
 		End


### PR DESCRIPTION
I have added expansion for `--with{out}-*` flags, which can be useful in certain areas, such as `configure` scripts. It essentially works exactly the same as the expansion of `--{no-}*` flags.

I have updated some of the unit tests, although I am not certain whether more are needed. What do you think about this change?