### PR TITLE
docs: remove outdated reference to Linuxbrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ make
 make install PREFIX=$HOME
 ```
 
-### Homebrew / Linuxbrew
+### Homebrew
 
 ```sh
 brew tap ko1nksm/getoptions


### PR DESCRIPTION
As of https://github.com/Linuxbrew/brew/commit/93389fde63974f096156344e281610acec44130c, Linuxbrew has been merged upstream into Homebrew. The Homebrew homepage (https://brew.sh/) now describes Homebrew as "The Missing Package Manager for macOS (or Linux)"