### PR TITLE
Proposal: add a 'mandatory' 'param' attribute

### DIFF
--- a/docs/References.md
+++ b/docs/References.md
@@ -296,6 +296,7 @@ They are available only in the `getoptions` and `getoptions_help` functions.
   - `hidden`:BOOLEAN - Do not display in help
   - `init`:[@INIT-VALUE | =STRING | CODE] - Initial value
   - `label`:STRING - Option part of help message
+  - `mandatory`:BOOLEAN - Flag parameter as mandatory
   - `pattern`:PATTERN - Pattern to accept
   - `validate`:STATEMENT - Code for value validation
   - `var`:STRING - Variable name displayed in help

--- a/examples/advanced.sh
+++ b/examples/advanced.sh
@@ -35,6 +35,7 @@ parser_definition() {
 	param   REGEX           --regex validate:'regex "^[1-9][0-9]*$"' \
 		-- '^[1-9][0-9]*$'
 	param   :multiple       --multiple init:'MULTIPLE=""' var:MULTIPLE
+	param   MANDATORY       --mandatory mandatory:true
 	array   ARRAY           --array init:'ARRAY=()' var:VALUE
 	parray 	PARRAY          --array-posix init:'PARRAY=""' var:VALUE
 	param   :'action "$1" p1 p2' --act1 --act2 var:param
@@ -48,6 +49,7 @@ parser_definition() {
 error() {
 	case $2 in
 		unknown) echo "$1" ;;
+		mandatory) echo "$1" ;;
 		number:*) echo "Not a number: $3" ;;
 		range:1) echo "Not a number: $3" ;;
 		range:2) echo "Out of range ($5 - $6): $3"; return 2 ;;
@@ -132,6 +134,7 @@ echo "PATTERN: $PATTERN"
 echo "BLOOD_TYPE: $BLOOD_TYPE"
 echo "REGEX: $REGEX"
 echo "MULTIPLE: $MULTIPLE"
+echo "MANDATORY: $MANDATORY"
 if [ ${#ARRAY[@]} -eq 0 ]; then
 	disp_array ARRAY
 else

--- a/examples/basic.sh
+++ b/examples/basic.sh
@@ -11,16 +11,17 @@ parser_definition() {
 		"Usage: $PROG [options...] [arguments...]" ''
 	msg -- 'getoptions basic example' ''
 	msg -- 'Options:'
-	flag    FLAG_A  -a                                        -- "message a"
-	flag    FLAG_B  -b                                        -- "message b"
-	flag    FLAG_F  -f +f --{no-}flag                         -- "expands to --flag and --no-flag"
-	flag    FLAG_W        --with{out}-flag                    -- "expands to ---with-flag and --without-flag"
-	flag    VERBOSE -v    --verbose   counter:true init:=0    -- "e.g. -vvv is verbose level 3"
-	param   PARAM   -p    --param     pattern:"foo | bar"     -- "accepts --param value / --param=value"
-	param   NUMBER  -n    --number    validate:number         -- "accepts only a number value"
-	option  OPTION  -o    --option    on:"default"            -- "accepts -ovalue / --option=value"
-	disp    :usage  -h    --help
-	disp    VERSION       --version
+	flag    FLAG_A    -a                                        -- "message a"
+	flag    FLAG_B    -b                                        -- "message b"
+	flag    FLAG_F    -f +f --{no-}flag                         -- "expands to --flag and --no-flag"
+	flag    FLAG_W          --with{out}-flag                    -- "expands to ---with-flag and --without-flag"
+	flag    VERBOSE   -v    --verbose   counter:true init:=0    -- "e.g. -vvv is verbose level 3"
+	param   PARAM     -p    --param     pattern:"foo | bar"     -- "accepts --param value / --param=value"
+	param   NUMBER    -n    --number    validate:number         -- "accepts only a number value"
+	param   MANDATORY -m    --mandatory mandatory:true          -- "this parameter is mandatory, cannot be omitted"
+	option  OPTION    -o    --option    on:"default"            -- "accepts -ovalue / --option=value"
+	disp    :usage    -h    --help
+	disp    VERSION         --version
 }
 
 number() { case $OPTARG in (*[!0-9]*) return 1; esac; }
@@ -34,6 +35,7 @@ echo "FLAG_W: $FLAG_W"
 echo "VERBOSE: $VERBOSE"
 echo "PARAM: $PARAM"
 echo "NUMBER: $NUMBER"
+echo "MANDATORY: $MANDATORY"
 echo "OPTION: $OPTION"
 echo "VERSION: $VERSION"
 i=0

--- a/lib/getoptions_base.sh
+++ b/lib/getoptions_base.sh
@@ -69,7 +69,7 @@ getoptions() {
 
 	_0 "${_def:-$2}() {"
 	_1 'OPTIND=$(($#+1))'
-	for mflag in $_mflags; do _1 "$(printf '%s' "$mflag" | tr '-' '_')_flag_declared=\"false\""; done
+	for mflag in $(printf '%s' "$_mflags"); do _1 "$(printf '%s' "$mflag" | tr '-' '_')_flag_declared=\"false\""; done
 	_1 "while OPTARG= && [ \"\${$_rest}\" != x ] && [ \$# -gt 0 ]; do"
 	[ "$_abbr" ] && getoptions_abbr "$@"
 
@@ -188,7 +188,7 @@ getoptions() {
 	_1 "done"
 	if [ -n "$_mflags" ]; then
 		_1 '[ $# -eq 0 ] &&'
-		for mflag in $_mflags; do
+		for mflag in $(printf '%s' "$_mflags"); do
 			_2 "[ \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" = \"true\" ] &&"
 		done
 		_2 '{'
@@ -208,7 +208,7 @@ getoptions() {
 	if [ -n "$_mflags" ]; then
 		_2 '*)'
 		i=0
-		for mflag in $_mflags; do
+		for mflag in $(printf '%s' "$_mflags"); do
 			ind() { if [ "$i" -eq 0 ]; then "_3" "$@"; else "_4" "$@"; fi }
 			ind "{ [ -z \"\${1:-}\" ] && [ -z \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" ] && set \"Mandatory argument: ${mflag}\" \"mandatory\" \"${mflag}\"; } ||"
 			i=$((i + 1))

--- a/lib/getoptions_base.sh
+++ b/lib/getoptions_base.sh
@@ -210,7 +210,7 @@ getoptions() {
 		i=0
 		for mflag in $_mflags; do
 			ind() { if [ "$i" -eq 0 ]; then "_3" "$@"; else "_4" "$@"; fi }
-			ind "{ [ -z \"\${1:-}\" ] && [ -z \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" ] && set \"Mandatory argument: ${mflag}\" \"mandatory ${mflag}\"; } ||"
+			ind "{ [ -z \"\${1:-}\" ] && [ -z \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" ] && set \"Mandatory argument: ${mflag}\" \"mandatory\" \"${mflag}\"; } ||"
 			i=$((i + 1))
 		done
 		_4 'set "Validation error ($1): $2" "$@"'

--- a/lib/getoptions_base.sh
+++ b/lib/getoptions_base.sh
@@ -2,7 +2,7 @@
 # [getoptions] License: Creative Commons Zero v1.0 Universal
 getoptions() {
 	_error="" _on=1 _no="" _export="" _plus="" _mode="" _alt="" _rest="" _def=""
-	_flags="" _nflags="" _opts="" _help="" _abbr="" _cmds="" _init=@empty IFS=" "
+	_flags="" _nflags="" _mflags="" _opts="" _help="" _abbr="" _cmds="" _init=@empty IFS=" "
 	[ $# -lt 2 ] && set -- "${1:?No parser definition}" -
 	[ "$2" = - ] && _def=getoptions_parse
 
@@ -69,11 +69,12 @@ getoptions() {
 
 	_0 "${_def:-$2}() {"
 	_1 'OPTIND=$(($#+1))'
+	for mflag in $_mflags; do _1 "$(printf '%s' "$mflag" | tr '-' '_')_flag_declared=\"false\""; done
 	_1 "while OPTARG= && [ \"\${$_rest}\" != x ] && [ \$# -gt 0 ]; do"
 	[ "$_abbr" ] && getoptions_abbr "$@"
 
 	args() {
-		sw="" validate="" pattern="" counter="" on=$_on no=$_no export=$_export
+		sw="" validate="" pattern="" counter="" on=$_on no=$_no export=$_export mandatory=""
 		while loop "$@" && shift; do
 			case $1 in
 				--\{no-\}*) i=${1#--?no-?}; sw "'--$i'|'--no-$i'" ;;
@@ -98,6 +99,11 @@ getoptions() {
 	_param() {
 		args "$@"
 		_3 "$sw)"
+		[ "$mandatory" ] && {
+			mflag=$(printf '%s' "$sw" | awk -F'|' '{ print $1 }' | tr -d "'" | tr -d '[:space:]')
+			if [ -n "$_mflags" ]; then _mflags="${_mflags} ${mflag}"; else _mflags="$mflag"; fi
+			_4 "$(printf '%s' "$mflag" | tr '-' '_')_flag_declared=\"true\""
+		}
 		_4 '[ $# -le 1 ] && set "required" "$1" && break'
 		_4 'OPTARG=$2'
 		valid "$1" '$OPTARG'
@@ -180,14 +186,38 @@ getoptions() {
 	_2 "esac"
 	_2 "shift"
 	_1 "done"
-	_1 '[ $# -eq 0 ] && { OPTIND=1; unset OPTARG; return 0; }'
-	_1 'case $1 in'
+	if [ -n "$_mflags" ]; then
+		_1 '[ $# -eq 0 ] &&'
+		for mflag in $_mflags; do
+			_2 "[ \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" = \"true\" ] &&"
+		done
+		_2 '{'
+		_3 'OPTIND=1'
+		_3 'unset OPTARG'
+		_3 'return 0'
+		_2 '}'
+	else
+		_1 '[ $# -eq 0 ] && { OPTIND=1; unset OPTARG; return 0; }'
+	fi
+	_1 'case ${1:-} in'
 	_2 'unknown) set "Unrecognized option: $2" "$@" ;;'
 	_2 'noarg) set "Does not allow an argument: $2" "$@" ;;'
 	_2 'required) set "Requires an argument: $2" "$@" ;;'
 	_2 'pattern:*) set "Does not match the pattern (${1#*:}): $2" "$@" ;;'
 	_2 'notcmd) set "Not a command: $2" "$@" ;;'
-	_2 '*) set "Validation error ($1): $2" "$@"'
+	if [ -n "$_mflags" ]; then
+		_2 '*)'
+		i=0
+		for mflag in $_mflags; do
+			ind() { if [ "$i" -eq 0 ]; then "_3" "$@"; else "_4" "$@"; fi }
+			ind "{ [ -z \"\${1:-}\" ] && [ -z \"\${$(printf '%s' "$mflag" | tr '-' '_')_flag_declared:-}\" ] && set \"Mandatory argument: ${mflag}\" \"mandatory ${mflag}\"; } ||"
+			i=$((i + 1))
+		done
+		_4 'set "Validation error ($1): $2" "$@"'
+		_3 ';;'
+	else
+		_2 '*) set "Validation error ($1): $2" "$@" ;;'
+	fi
 	_1 "esac"
 	[ "$_error" ] && _1 "$_error" '"$@" >&2 || exit $?'
 	_1 'echo "$1" >&2'

--- a/spec/getoptions_abbr_spec.sh
+++ b/spec/getoptions_abbr_spec.sh
@@ -116,4 +116,28 @@ Describe "getoptions_abbr()"
 			The status should be failure
 		End
 	End
+
+	Context "when a mandatory parameter is defined with a long option"
+		parser_definition() { setup ARGS abbr:true; param PARAM --param mandatory:true; }
+
+		It "treats an abbreviation option"
+			When call parse --p=value
+			The variable PARAM should eq "value"
+		End
+	End
+
+	Context "when a mandatory parameter is defined with a long and short option"
+		parser_definition() { setup ARGS abbr:true; param PARAM -p --param abbr: mandatory:true; }
+
+		It "does not treat as an abbreviation option"
+			When run parse --p=value
+			The stderr should eq "Unrecognized option: --p"
+			The status should be failure
+		End
+
+		It "treats a short option"
+			When call parse -p value
+			The variable PARAM should eq "value"
+		End
+	End
 End

--- a/spec/getoptions_base_spec.sh
+++ b/spec/getoptions_base_spec.sh
@@ -176,6 +176,52 @@ Describe "getoptions()"
 			End
 		End
 
+		Context "when missing a mandatory parameter"
+			parser_definition() { setup ARGS; param PARAM --param mandatory:true; }
+			It "displays error"
+				When run parse
+				The stderr should eq "Mandatory argument: --param"
+				The status should be failure
+			End
+		End
+
+		Context "when missing a mandatory parameter with an unknown option"
+			parser_definition() { setup ARGS; param PARAM --param mandatory:true; }
+			It "displays error"
+				When run parse -x
+				The stderr should eq "Unrecognized option: -x"
+				The status should be failure
+			End
+		End
+
+		Context "when missing a mandatory parameter with a failing parameter validation"
+			parser_definition() {
+				setup ARGS
+				param PARAM1 --param1 mandatory:true
+				param PARAM2 --param2 validate:'valid'
+			}
+			valid() { return 1; }
+			It "displays error"
+				When run parse --param2 "invalid"
+				The stderr should eq "Validation error (valid:1): --param2"
+				The status should be failure
+			End
+		End
+
+		Context "when missing a mandatory parameter with multiple missing mandatory parameters"
+			parser_definition() {
+				setup ARGS
+				param PARAM1 --param1
+				param PARAM2 --param2 mandatory:true
+				param PARAM3 --param3 mandatory:true
+			}
+			It "displays error"
+				When run parse --param1 "value"
+				The stderr should eq "Mandatory argument: --param2"
+				The status should be failure
+			End
+		End
+
 		Context 'when the plus attribute enabled'
 			parser_definition() { setup ARGS plus:true; }
 			It "displays error if unknown +option specified"
@@ -229,6 +275,7 @@ Describe "getoptions()"
 			setup RESTARGS error
 			param PARAM -p
 			param PARAM -q
+			param PARAM -m mandatory:true
 			param PARAM --pattern pattern:'foo | bar'
 			param VALID -v validate:'valid "$1"'
 			param ARG --arg validate:arg
@@ -238,13 +285,14 @@ Describe "getoptions()"
 		arg() { false; }
 		error() {
 			case $2 in
-				unknown) echo "custom $2: $3 [$OPTARG]"; return 20 ;;
-				valid:3) echo "valid $2: $3 [$OPTARG]"; return 30 ;;
-				pattern:'foo | bar') echo "pattern $2: $3 [$OPTARG]"; return 40 ;;
+				unknown) echo "custom $2: ${3:-} [$OPTARG]"; return 20 ;;
+				valid:3) echo "valid $2: ${3:-} [$OPTARG]"; return 30 ;;
+				pattern:'foo | bar') echo "pattern $2: ${3:-} [$OPTARG]"; return 40 ;;
+				mandatory) echo "custom $2: ${3:-} [$OPTARG]"; return 50 ;;
 				arg:*) echo "invalid argument [$OPTARG]"; return 1 ;;
 				noarg) echo "noarg [$OPTARG]"; return 1 ;;
 			esac
-			[ "$3" = "-q" ] && echo "$1 [$OPTARG]" && return 1
+			[ "${3:-}" = "-q" ] && echo "$1 [$OPTARG]" && return 1
 			return 0
 		}
 
@@ -276,6 +324,12 @@ Describe "getoptions()"
 			When run parse --pattern baz
 			The stderr should eq "pattern pattern:foo | bar: --pattern [baz]"
 			The status should eq 40
+		End
+
+		It "receives mandatory"
+			When run parse
+			The stderr should eq "custom mandatory: -m []"
+			The status should eq 50
 		End
 
 		It "can refer to the OPTARG variable"


### PR DESCRIPTION
Hi,
This pull request addresses the problems cited in the issue https://github.com/ko1nksm/getoptions/issues/41.

I think it would be a good idea to have a way to flag a parameter as mandatory, so we don't need to implement checks for all necessary parameters after the argument parsing :)

## Implementation

To track if the parameter was passed to the parser, I created a "control variable" to check if the flag is defined. For a parameter with a short option `-p`, the variable is name `_p_flag_declared`. For example:

```shell
parse() {
  ...
  case $1 in
  '-p')
    _p_flag_declared="true"
    [ $# -le 1 ] && set "required" "$1" && break
    ...
```

For a parameter with a long option `--param`, it would be `__param_flag_declared`. And for a parameter with both short and long options `-p | --param`, it uses the short option `_p_flag_declared`.

If we want to know which parameter was not defined, we cannot set an error like the other errors using something like `set "mandatory" "$1" && break` because if the parameter was not defined, it will never reach this `set` statement inside the switch case.

After the switch case is done, even if the list of arguments is still empty, we need to check for the control variables for the mandatory parameters:

```shell
[ $# -eq 0 ] &&
  [ "${_p_flag_declared:-}" = "true" ] &&
  {
    OPTIND=1
    unset OPTARG
    return 0
  }
```

Then, we parse the error after all the other errors:

```shell
case ${1:-} in
unknown) set "Unrecognized option: $2" "$@" ;;
noarg) set "Does not allow an argument: $2" "$@" ;;
required) set "Requires an argument: $2" "$@" ;;
pattern:*) set "Does not match the pattern (${1#*:}): $2" "$@" ;;
notcmd) set "Not a command: $2" "$@" ;;
*)
  { [ -z "${1:-}" ] && [ -z "${_p_flag_declared:-}" ] && set "Mandatory argument: -p" "mandatory" "-p"; } ||
    set "Validation error ($1): $2" "$@"
  ;;
```

If  `$1` is empty _and_ the control variable is also empty, it means we are missing a mandatory parameter. Else, we have another validation error.

## Docs

- Added to `docs/Reference.md:param:attributes`: `mandatory`:BOOLEAN - Flag parameter as mandatory
- Added flag to `examples/advanced.sh:parser_definition`
- Added flag to `examples/basic.sh:parser_definition`

## Tests

### `getoptions_base_spec.sh`

When a mandatory parameter is missing:

```shell
# parser_definition() { setup ARGS; param PARAM --param mandatory:true; }
$ my_script.sh
> Mandatory argument: --param
```

Other errors have priority over the mandatory parameter:

```shell
# parser_definition() { setup ARGS; param PARAM --param mandatory:true; }
$ my_script.sh -x
> Unrecognized option: -x
```

```shell
# parser_definition() {
#   setup ARGS
#   param PARAM1 --param1 mandatory:true
#   param PARAM2 --param2 validate:'valid'
# }
# valid() { return 1; }
$ my_script.sh --param2 "invalid"
> Validation error (valid:1): --param2
```

For multiple mandatory parameters, it will respect the order of the parser definition:

```shell
# parser_definition() {
#   setup ARGS
#   param PARAM1 --param1
#   param PARAM2 --param2 mandatory:true
#   param PARAM3 --param3 mandatory:true
# }
$ my_script.sh --param1 "value"
> Mandatory argument: --param2
```

Custom error handling:

```shell
# parser_definition() {
#   setup RESTARGS error
#   param PARAM -p
#   param PARAM -q
#   param PARAM -m mandatory:true
#   param PARAM --pattern pattern:'foo | bar'
#   param VALID -v validate:'valid "$1"'
#   param ARG --arg validate:arg
#   flag  FLAG --flag
# }
# valid() { [ "$1" = "-v" ] && return 3; }
# arg() { false; }
# error() {
#   case $2 in
#     unknown) echo "custom $2: ${3:-} [$OPTARG]"; return 20 ;;
#     valid:3) echo "valid $2: ${3:-} [$OPTARG]"; return 30 ;;
#     pattern:'foo | bar') echo "pattern $2: ${3:-} [$OPTARG]"; return 40 ;;
#     mandatory) echo "custom $2: ${3:-} [$OPTARG]"; return 50 ;;
#     arg:*) echo "invalid argument [$OPTARG]"; return 1 ;;
#     noarg) echo "noarg [$OPTARG]"; return 1 ;;
#   esac
#   [ "${3:-}" = "-q" ] && echo "$1 [$OPTARG]" && return 1
#   return 0
# }
$ my_script.sh
> Mandatory argument: custom mandatory: -m []
> Status code: 50
```

### `getoptions_abbr_spec.sh`

`abbr` enabled and mandatory parameter defined with a long option:

```shell
# parser_definition() { setup ARGS abbr:true; param PARAM --param mandatory:true; }
$ my_script.sh --p=value
> PARAM=value
```

`abbr` enabled globally but disabled for mandatory parameter and parameter defined with long and short option:

```shell
# parser_definition() { setup ARGS abbr:true; param PARAM -p --param abbr: mandatory:true; }
$ my_script.sh --p=value
> Unrecognized option: --p
```

```shell
# parser_definition() { setup ARGS abbr:true; param PARAM -p --param abbr: mandatory:true; }
$ my_script.sh -p value
> PARAM=value
```